### PR TITLE
Update UUID generation library

### DIFF
--- a/lib/middleware/correlate.js
+++ b/lib/middleware/correlate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var log  = require('../logger');
 
 /**

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express-validator": "^2.18.0",
     "ip": "^0.3.2",
     "konfig": "^0.2.1",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.0.0",
     "optional": "^0.1.3",
     "vitalsigns": "^0.4.3",
     "zoologist": "^0.4.14"


### PR DESCRIPTION
node-uuid (deprecated) updated to uuid (https://www.npmjs.com/package/uuid).