### PR TITLE
Validator constructor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,5 @@ app.use(micro([options]));
 - `monitorsPath`: `String` Path to load monitors. Defaults to `monitors`.
 - `partialResponseQuery`: `String` The query parameter to use for partial reponse. Defaults to `fields`.
 - `correlationHeaderName`: `String` The name of your correlation header. Defaults to `X-CorrelationID`.
-- `enableBodyParsing`: `boolean` Enable or disable body parsing, useful to disable when dealign with content other than JSON. Defaults to `true`.
+- `enableBodyParsing`: `boolean` Enable or disable body parsing, useful to disable when dealign with content other than JSON. Enables express-validator. Defaults to `true`.
+- `validatorOptions`: `object` Enable express-validator with these options. Defaults to `null`.

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ var buildOptions = function(options) {
   options.partialResponseQuery  = options.partialResponseQuery || 'fields';
   options.correlationHeaderName = options.correlationHeaderName || 'X-CorrelationID';
   options.enableBodyParsing     = options.enableBodyParsing || true;
+  options.validatorOptions      = options.validatorOptions || null;
 
   // Return now if we have no config
   if (!config.app) {

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -39,7 +39,9 @@ module.exports = function (app, options) {
 
     // Parse application/json / validators
     app.use(bodyParser.json());
-    app.use(validator());
+  }
+  if (options.enableBodyParsing || options.validatorOptions) {
+    app.use(validator(options.validatorOptions));
   }
 
   // Partial Response

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-microservice-starter",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "An express-based Node.js API bootstrapping module for microservices.",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "express-cache-response-directive": "^1.0.0",
     "express-enrouten": "^1.2.1",
     "express-partial-response": "^0.3.4",
-    "express-validator": "^2.18.0",
+    "express-validator": "^3.0.0",
     "ip": "^0.3.2",
     "konfig": "^0.2.1",
     "uuid": "^3.0.0",


### PR DESCRIPTION
* Pull in newer express-validator (specifically to address https://github.com/ctavan/express-validator/issues/30).
* Allow passing validator constructor options in.